### PR TITLE
js: update to API v3, allow filtering by labels

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -9,8 +9,12 @@
     <h1>github-issues-widget Demo</h1>
     <div id="github-issues-widget"></div>
     <script type="text/javascript">
-      GITHUB_ISSUES_USER = "emmapersky";
+      GITHUB_ISSUES_USER = "oneclickorgs";
       GITHUB_ISSUES_REPO = "one-click-orgs";
+      /* Uncomment the following line to filter issues by one or more labels.*/
+      // GITHUB_ISSUES_LABELS = "feature";
+      /* To filter by multiple labels use a CSV string: */
+      // GITHUB_ISSUES_LABELS = "feature,bug";
     </script>
     <script type="text/javascript" src="github-issues-widget.js"></script>
   </body>

--- a/github-issues-widget.js
+++ b/github-issues-widget.js
@@ -14,20 +14,45 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+function is_defined(variable){
+  return typeof(variable) == "undefined"
+}
+
+function is_string(input){
+  return typeof(input)=='string';
+}
+
+function alert_key_value_pairs(map){
+  for (var key in map) {
+    alert([key, map[key]].join("\n\n"));
+  }
+}
+
+function error(msg){
+  alert("!!! ERROR - " + msg);
+}
+
 var GithubIssuesWidget = {};
-GithubIssuesWidget.url = "http://github.com/api/v2/json/issues/list/" + GITHUB_ISSUES_USER + "/" + GITHUB_ISSUES_REPO + "/open?callback=?";
+GithubIssuesWidget.url = "https://api.github.com/repos/" + GITHUB_ISSUES_USER + "/" + GITHUB_ISSUES_REPO + "/issues?callback=?"
+if(typeof window.GITHUB_ISSUES_LABELS != "undefined") {
+  if(is_string(GITHUB_ISSUES_LABELS)) {
+    GithubIssuesWidget.url += "&labels=" + GITHUB_ISSUES_LABELS;
+  } else {
+    error("GITHUB_ISSUES_LABELS must be a string, ignoring label filter");
+  }
+}
 GithubIssuesWidget.go = function () {
   $('#github-issues-widget').append('<p class="loading">Loading...</p>');
   $.getJSON(this.url, function (data) {
     var list = $('<ul></ul>');
-    $.each(data.issues, function (issueIndex, issue) {
-      var issueUrl = 'http://github.com/' + GITHUB_ISSUES_USER + '/' + GITHUB_ISSUES_REPO + '/issues#issue/' + issue.number;
+    $.each(data.data, function (issueIndex, issue) {
       var issueHtml = "<li>";
-      issueHtml += '<a href="' + issueUrl + '">';
+      issueHtml += '<a href="' + issue.html_url+ '">';
       issueHtml += issue.title;
       issueHtml += "</a>";
       $.each(issue.labels, function (labelIndex, label) {
-        issueHtml += '<span class="label">' + label + '</span>';
+        issueHtml += '<span class="label">' + label.name + '</span>';
       });
       issueHtml += "</li>";
       list.append(issueHtml);


### PR DESCRIPTION
added GITHUB_ISSUES_LABELS global variable to demo.html for filtering
issues by labels. this variable is completely optional and must be a
string if provided (alerts user if it is not). to specify multiple
labels, use a CSV string.
